### PR TITLE
fix: stability fixes and Ice menu-bar-manager compatibility

### DIFF
--- a/Aidente/AppDelegate.swift
+++ b/Aidente/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import Defaults
 import Darwin
 import IOKit
+import IOKit.pwr_mgt
 import Observation
 import UserNotifications
 
@@ -12,6 +13,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var viewModel: MenuViewModel!
     private var chargeManager: ChargeManager!
     private var settingsWindowController: SettingsWindowController!
+    private var powerNotificationPort: IONotificationPortRef?
+    private var powerNotifier: io_object_t = 0
+    private var rootPowerDomainPort: io_connect_t = 0
+
+    // IOMessage.h defines these via the iokit_common_msg() function-like
+    // macro, which Swift cannot import.
+    private static let messageCanSystemSleep: UInt32 = 0xE000_0270
+    private static let messageSystemWillSleep: UInt32 = 0xE000_0280
+    private static let messageSystemHasPoweredOn: UInt32 = 0xE000_0300
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AidenteMigration.migrateLegacyPreferencesIfNeeded()
@@ -116,6 +126,51 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func observePowerEvents() {
+        // IORegisterForSystemPower lets the app hold off sleep until the
+        // charging pause has actually reached the SMC; NSWorkspace's
+        // willSleepNotification offers no such acknowledgment.
+        let refCon = Unmanaged.passUnretained(self).toOpaque()
+        rootPowerDomainPort = IORegisterForSystemPower(
+            refCon,
+            &powerNotificationPort,
+            { refCon, _, messageType, messageArgument in
+                guard let refCon else { return }
+                let delegate = Unmanaged<AppDelegate>.fromOpaque(refCon)
+                    .takeUnretainedValue()
+                MainActor.assumeIsolated {
+                    delegate.handlePowerMessage(messageType, argument: messageArgument)
+                }
+            },
+            &powerNotifier
+        )
+        guard rootPowerDomainPort != 0, let powerNotificationPort else {
+            observeWorkspacePowerEvents()
+            return
+        }
+        IONotificationPortSetDispatchQueue(powerNotificationPort, DispatchQueue.main)
+    }
+
+    private func handlePowerMessage(
+        _ messageType: UInt32,
+        argument: UnsafeMutableRawPointer?
+    ) {
+        let notificationID = Int(bitPattern: argument)
+        switch messageType {
+        case Self.messageCanSystemSleep:
+            IOAllowPowerChange(rootPowerDomainPort, notificationID)
+        case Self.messageSystemWillSleep:
+            Task {
+                await chargeManager.prepareForSleep()
+                IOAllowPowerChange(rootPowerDomainPort, notificationID)
+            }
+        case Self.messageSystemHasPoweredOn:
+            chargeManager.resumeFromSleep()
+        default:
+            break
+        }
+    }
+
+    private func observeWorkspacePowerEvents() {
         NSWorkspace.shared.notificationCenter.addObserver(
             self,
             selector: #selector(handleSystemWillSleep(_:)),
@@ -131,7 +186,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handleSystemWillSleep(_ notification: Notification) {
-        chargeManager.prepareForSleep()
+        Task {
+            await chargeManager.prepareForSleep()
+        }
     }
 
     @objc private func handleSystemDidWake(_ notification: Notification) {
@@ -158,5 +215,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         chargeManager.stop()
         batteryService.stop()
         NSWorkspace.shared.notificationCenter.removeObserver(self)
+        if rootPowerDomainPort != 0 {
+            IODeregisterForSystemPower(&powerNotifier)
+            IOServiceClose(rootPowerDomainPort)
+            rootPowerDomainPort = 0
+        }
+        if let powerNotificationPort {
+            IONotificationPortDestroy(powerNotificationPort)
+            self.powerNotificationPort = nil
+        }
     }
 }

--- a/Aidente/Services/BatteryService.swift
+++ b/Aidente/Services/BatteryService.swift
@@ -172,7 +172,11 @@ class BatteryService {
         }
 
         return await withCheckedContinuation { continuation in
-            helper.readBatteryMetrics { batteryVoltage, batteryCurrent, batteryPower in
+            helper.readBatteryMetrics { success, batteryVoltage, batteryCurrent, batteryPower in
+                guard success else {
+                    continuation.resume(returning: nil)
+                    return
+                }
                 continuation.resume(
                     returning: SMCBatteryReading(
                         batteryVoltage: batteryVoltage,
@@ -197,7 +201,11 @@ class BatteryService {
         }
 
         return await withCheckedContinuation { continuation in
-            helper.readAdapterMetrics { adapterVoltage, adapterCurrent, adapterPower in
+            helper.readAdapterMetrics { success, adapterVoltage, adapterCurrent, adapterPower in
+                guard success else {
+                    continuation.resume(returning: nil)
+                    return
+                }
                 continuation.resume(
                     returning: SMCAdapterReading(
                         adapterVoltage: adapterVoltage,
@@ -214,7 +222,7 @@ class BatteryService {
         async let adapterData = fetchSMCAdapterData()
 
         guard let batteryReading = await batteryData, let adapterReading = await adapterData else {
-            logger.error("No helper available for SMC battery polling")
+            logger.error("SMC poll failed; keeping last known metrics")
             return
         }
 
@@ -320,7 +328,8 @@ class BatteryService {
                 return
             }
 
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 3) {
+            // Generous enough to cover launchd cold-starting the helper daemon.
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 10) {
                 commandReply.finish(.failure(XPCError.timeout))
             }
 

--- a/Aidente/Services/ChargeManager.swift
+++ b/Aidente/Services/ChargeManager.swift
@@ -522,7 +522,9 @@ class ChargeManager {
         guard ChargingHelperManager.shared.isInstalled else { return }
         let capabilities = batteryService.deviceCapabilities
         if capabilities.chargingControl {
-            setCharging(enabled: true)
+            // Restoring defaults after unplugging is not a charging-state
+            // change the user should be notified about.
+            setCharging(enabled: true, notify: false)
         }
         if capabilities.adapterControl {
             setAdapter(enabled: true)
@@ -532,7 +534,7 @@ class ChargeManager {
         }
     }
 
-    private func setCharging(enabled: Bool, reason: String? = nil) {
+    private func setCharging(enabled: Bool, reason: String? = nil, notify: Bool = true) {
         chargingCommandGeneration += 1
         let commandGeneration = chargingCommandGeneration
         logger.info("Setting charging: \(enabled)")
@@ -543,7 +545,9 @@ class ChargeManager {
                 serviceControlError = nil
                 chargingControlError = nil
                 batteryService.scheduleSinglePoll()
-                sendChargingStateNotification(charging: enabled, reason: reason)
+                if notify {
+                    sendChargingStateNotification(charging: enabled, reason: reason)
+                }
                 if !enabled {
                     try? await Task.sleep(for: .seconds(6))
                     guard commandGeneration == chargingCommandGeneration else { return }

--- a/Aidente/Services/ChargeManager.swift
+++ b/Aidente/Services/ChargeManager.swift
@@ -742,9 +742,17 @@ class ChargeManager {
         }
     }
 
-    func prepareForSleep() {
+    func prepareForSleep() async {
         isSystemSleeping = true
         evaluate(controlState: batteryService.controlState)
+        guard Defaults[.manageCharging],
+            Defaults[.stopChargingWhileSleeping],
+            batteryService.controlState.adapterConnected,
+            batteryService.deviceCapabilities.chargingControl
+        else { return }
+        // evaluate() applies the pause in a fire-and-forget task; await a direct
+        // command so the write reaches the SMC before sleep is acknowledged.
+        try? await batteryService.manageBatteryCharging(enabled: false)
     }
 
     func resumeFromSleep() {

--- a/Aidente/Services/LaunchAtLoginService.swift
+++ b/Aidente/Services/LaunchAtLoginService.swift
@@ -2,7 +2,7 @@ import Foundation
 import ServiceManagement
 import os.log
 
-class LaunchAtLoginService {
+final class LaunchAtLoginService: Sendable {
     static let shared = LaunchAtLoginService()
 
     private let logger = Logger(

--- a/Aidente/StatusBarManager.swift
+++ b/Aidente/StatusBarManager.swift
@@ -3,11 +3,12 @@ import Defaults
 import SwiftUI
 
 @MainActor
-final class StatusBarManager: NSObject, NSPopoverDelegate {
+final class StatusBarManager: NSObject {
     private let statusItem: NSStatusItem
     private let viewModel: MenuViewModel
     private let settingsWindowController: SettingsWindowController
-    private let popover = NSPopover()
+    private var dashboardPanel: NSPanel?
+    private var dismissMonitors: [Any] = []
     private var displayObservation: Task<Void, Never>?
     private var previewWindow: NSWindow?
 
@@ -22,22 +23,33 @@ final class StatusBarManager: NSObject, NSPopoverDelegate {
         )
         super.init()
 
-        configurePopover()
         setupPersistentHostingView()
         startDisplayObservation()
     }
 
-    private func configurePopover() {
-        let rootView = makeDashboardRootView()
+    // A fixed-position panel instead of an NSPopover: popovers track their
+    // anchor, so menu bar managers like Ice that relocate status items to
+    // hide them would drag the open popover along (breaking an in-progress
+    // charge-limit drag) or dismiss it outright.
+    private func makeDashboardPanel() -> NSPanel {
+        let hostingController = NSHostingController(rootView: makeDashboardRootView())
+        hostingController.view.wantsLayer = true
+        hostingController.view.layer?.cornerRadius = 15
+        hostingController.view.layer?.masksToBounds = true
 
-        popover.contentSize = NSSize(width: 408, height: 720)
-        popover.behavior = .transient
-        popover.animates = true
-        popover.delegate = self
-        popover.contentViewController = NSHostingController(rootView: rootView)
-        popover.contentViewController?.view.wantsLayer = true
-        popover.contentViewController?.view.layer?.cornerRadius = 15
-        popover.contentViewController?.view.layer?.masksToBounds = true
+        let panel = AidenteFloatingPanel(contentViewController: hostingController)
+        panel.styleMask = [.borderless, .nonactivatingPanel]
+        panel.setContentSize(NSSize(width: 408, height: 720))
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .statusBar
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.appearance = NSAppearance(named: .darkAqua)
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false
+        panel.animationBehavior = .utilityWindow
+        return panel
     }
 
     private func makeDashboardRootView() -> DashboardPopoverView {
@@ -45,7 +57,7 @@ final class StatusBarManager: NSObject, NSPopoverDelegate {
             viewModel: viewModel,
             onOpenSettings: { [weak self] tab in
                 guard let self else { return }
-                self.popover.performClose(nil)
+                self.closeDashboard()
                 self.previewWindow?.close()
                 self.settingsWindowController.showSettings(tab: tab)
             },
@@ -53,6 +65,82 @@ final class StatusBarManager: NSObject, NSPopoverDelegate {
                 self?.viewModel.quit()
             }
         )
+    }
+
+    private func showDashboard() {
+        guard let button = statusItem.button else { return }
+        let panel = dashboardPanel ?? makeDashboardPanel()
+        dashboardPanel = panel
+
+        let size = panel.frame.size
+        if let buttonWindow = button.window {
+            let buttonFrame = buttonWindow.convertToScreen(
+                button.convert(button.bounds, to: nil)
+            )
+            let screenFrame =
+                (buttonWindow.screen ?? NSScreen.main)?.visibleFrame
+                ?? buttonFrame
+            let x = min(
+                max(buttonFrame.midX - size.width / 2, screenFrame.minX + 8),
+                screenFrame.maxX - size.width - 8
+            )
+            let y = max(buttonFrame.minY - size.height - 6, screenFrame.minY)
+            panel.setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        viewModel.menuWillOpen()
+        panel.makeKeyAndOrderFront(nil)
+        panel.orderFrontRegardless()
+        installDismissMonitors()
+    }
+
+    private func closeDashboard() {
+        removeDismissMonitors()
+        guard let panel = dashboardPanel, panel.isVisible else { return }
+        panel.orderOut(nil)
+        viewModel.menuDidClose()
+    }
+
+    private func installDismissMonitors() {
+        guard dismissMonitors.isEmpty else { return }
+
+        let globalMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { _ in
+            Task { @MainActor [weak self] in
+                self?.closeDashboard()
+            }
+        }
+
+        let localMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .keyDown]
+        ) { event in
+            let consumeEvent = MainActor.assumeIsolated { [weak self] () -> Bool in
+                guard let self else { return false }
+                if event.type == .keyDown {
+                    guard event.keyCode == 53 else { return false }
+                    self.closeDashboard()
+                    return true
+                }
+                // Clicks on the status item itself are left to the button's
+                // toggle action so they don't close-then-reopen the panel.
+                if event.window == self.dashboardPanel
+                    || event.window == self.statusItem.button?.window
+                {
+                    return false
+                }
+                self.closeDashboard()
+                return false
+            }
+            return consumeEvent ? nil : event
+        }
+
+        dismissMonitors = [globalMonitor, localMonitor].compactMap { $0 }
+    }
+
+    private func removeDismissMonitors() {
+        dismissMonitors.forEach { NSEvent.removeMonitor($0) }
+        dismissMonitors.removeAll()
     }
 
     private func setupPersistentHostingView() {
@@ -109,37 +197,24 @@ final class StatusBarManager: NSObject, NSPopoverDelegate {
     }
 
     @objc private func togglePopover(_ sender: NSStatusBarButton) {
-        if popover.isShown {
-            popover.performClose(sender)
-            return
+        if let panel = dashboardPanel, panel.isVisible {
+            closeDashboard()
+        } else {
+            showDashboard()
         }
-
-        viewModel.menuWillOpen()
-        popover.show(
-            relativeTo: sender.bounds,
-            of: sender,
-            preferredEdge: .minY
-        )
-        popover.contentViewController?.view.window?.makeKey()
     }
 
     func showPopoverForPreview() {
-        guard let button = statusItem.button, !popover.isShown else { return }
+        guard dashboardPanel?.isVisible != true else { return }
         NSApp.activate(ignoringOtherApps: true)
-        viewModel.menuWillOpen()
-        popover.show(
-            relativeTo: button.bounds,
-            of: button,
-            preferredEdge: .minY
-        )
-        popover.contentViewController?.view.window?.makeKeyAndOrderFront(nil)
+        showDashboard()
     }
 
     func showWindowForPreview() {
         guard previewWindow == nil else { return }
 
         let hostingController = NSHostingController(rootView: makeDashboardRootView())
-        let panel = AidentePreviewPanel(contentViewController: hostingController)
+        let panel = AidenteFloatingPanel(contentViewController: hostingController)
         panel.styleMask = [.borderless]
         panel.setContentSize(NSSize(width: 408, height: 720))
         panel.isOpaque = false
@@ -172,16 +247,12 @@ final class StatusBarManager: NSObject, NSPopoverDelegate {
         panel.orderFrontRegardless()
     }
 
-    func popoverDidClose(_ notification: Notification) {
-        viewModel.menuDidClose()
-    }
-
     deinit {
         displayObservation?.cancel()
     }
 }
 
-private final class AidentePreviewPanel: NSPanel {
+private final class AidenteFloatingPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 }

--- a/Aidente/Views/BatteryIndicatorView.swift
+++ b/Aidente/Views/BatteryIndicatorView.swift
@@ -226,7 +226,7 @@ struct BatteryIndicatorView: View {
 }
 
 private struct InsidePercentageFramePreferenceKey: PreferenceKey {
-    static var defaultValue: CGRect?
+    static let defaultValue: CGRect? = nil
     static func reduce(value: inout CGRect?, nextValue: () -> CGRect?) {
         value = nextValue() ?? value
     }

--- a/ChargingHelper/ChargingHelper.swift
+++ b/ChargingHelper/ChargingHelper.swift
@@ -102,6 +102,21 @@ final class ChargingHelper: NSObject, AidenteControlProtocol {
         logger.info("Reset on disconnect: \(enabled)")
     }
 
+    // Preserving state across disconnects is only meant to keep the charge
+    // pause. A preserved force discharge would drain the battery to empty
+    // with the adapter plugged in, so it is always cleared.
+    func clearForceDischarge() {
+        guard battery.capabilities.forceDischargeControl else { return }
+        do {
+            if try battery.getForceDischarging() {
+                try battery.setForceDischarging(false)
+                logger.info("Force discharge cleared")
+            }
+        } catch {
+            logger.error("clearForceDischarge failed: \(error.localizedDescription)")
+        }
+    }
+
     func resetToDefaults() {
         do {
             if battery.capabilities.inhibitChargeControl {

--- a/ChargingHelper/main.swift
+++ b/ChargingHelper/main.swift
@@ -62,7 +62,8 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
                 logger.info("XPC connection invalidated, resetting SMC keys to defaults")
                 self.helper.resetToDefaults()
             } else {
-                logger.info("XPC connection invalidated, preserving the current SMC state")
+                logger.info("XPC connection invalidated, preserving the charge pause state")
+                self.helper.clearForceDischarge()
             }
             exit(0)
         }

--- a/Helper/Helper.swift
+++ b/Helper/Helper.swift
@@ -14,22 +14,22 @@ final class Helper: NSObject, AidenteReaderProtocol {
     )
 
     func readBatteryMetrics(
-        reply: @escaping @Sendable (Double, Double, Double) -> Void
+        reply: @escaping @Sendable (Bool, Double, Double, Double) -> Void
     ) {
         do {
             let batteryVoltage = try SMCBattery.getVoltage()
             let batteryCurrent = try SMCBattery.getCurrent()
             let batteryPower = batteryVoltage * batteryCurrent
 
-            reply(batteryVoltage, batteryCurrent, batteryPower)
+            reply(true, batteryVoltage, batteryCurrent, batteryPower)
         } catch {
             logger.error("SMC battery read failed: \(error.localizedDescription)")
-            reply(0, 0, 0)
+            reply(false, 0, 0, 0)
         }
     }
 
     func readAdapterMetrics(
-        reply: @escaping @Sendable (Double, Double, Double) -> Void
+        reply: @escaping @Sendable (Bool, Double, Double, Double) -> Void
     ) {
         do {
             var adapterVoltage = try SMCAdapter.getVoltage()
@@ -40,10 +40,10 @@ final class Helper: NSObject, AidenteReaderProtocol {
 
             let adapterPower = adapterVoltage * adapterCurrent
 
-            reply(adapterVoltage, adapterCurrent, adapterPower)
+            reply(true, adapterVoltage, adapterCurrent, adapterPower)
         } catch {
             logger.error("SMC adapter read failed: \(error.localizedDescription)")
-            reply(0, 0, 0)
+            reply(false, 0, 0, 0)
         }
     }
 

--- a/Shared/XPCProtocols.swift
+++ b/Shared/XPCProtocols.swift
@@ -2,10 +2,10 @@ import Foundation
 
 @objc public protocol AidenteReaderProtocol {
     func readBatteryMetrics(
-        reply: @escaping @Sendable (Double, Double, Double) -> Void
+        reply: @escaping @Sendable (Bool, Double, Double, Double) -> Void
     )
     func readAdapterMetrics(
-        reply: @escaping @Sendable (Double, Double, Double) -> Void
+        reply: @escaping @Sendable (Bool, Double, Double, Double) -> Void
     )
     func getCapabilities(
         reply: @escaping @Sendable (Bool, Bool, Bool, Bool) -> Void


### PR DESCRIPTION
## Summary

Six independent bug-fix commits, all verified on real hardware (M4 Pro, macOS 15):

1. **fix(helper)**: always clear force discharge when preserving SMC state on disconnect. Previously, if the app exited or crashed during a discharge/calibration phase with "stop charging when app closed" enabled, the Mac kept force-discharging on AC power until the battery was empty.
2. **fix**: guarantee the sleep charging pause reaches the SMC before the system sleeps, using `IORegisterForSystemPower` + `IOAllowPowerChange` instead of NSWorkspace notifications (which offer no acknowledgment, so the fire-and-forget XPC write could race system suspend). Falls back to NSWorkspace observers if registration fails.
3. **fix**: suppress the spurious "Charging Resumed" notification fired when unplugging the adapter (restoring SMC defaults re-enabled charging right after the dedup state was cleared).
4. **fix(xpc)**: reader replies now carry a success flag so transient SMC read failures keep the last known metrics instead of showing zeros; control command timeout raised 3s→10s to cover launchd cold-starting the daemon.
5. **fix(ui)**: replace the transient anchored NSPopover dashboard with a fixed-position non-activating floating panel. Menu bar managers like Ice hide status items by relocating them, which dismissed the open popover or dragged it mid-interaction — shifting local coordinates under the cursor and committing a bogus 100% charge limit during a slider drag. The panel is positioned once at open and closes on outside click / Esc / clicking the icon again.
6. **fix**: resolve two Swift 6 strict-concurrency errors so `swift build` works again.

## 中文摘要

六个独立修复：① 断开连接保留状态时强制清除强制放电标志（防止应用崩溃后插电放空电池）；② 睡眠前通过 IOKit 电源确认机制保证暂停充电写入 SMC，消除竞态；③ 拔电源不再弹虚假"已恢复充电"通知；④ 只读 XPC 携带成功标志、读取失败保留上次读数，控制命令超时 3s→10s；⑤ 仪表盘改为固定位置浮动面板，修复 Ice 等菜单栏管理工具导致面板被关闭、充电上限滑块误跳 100% 的问题；⑥ 修复两处 Swift 6 严格并发错误，恢复 `swift build`。

## Compatibility / Verification

- The `AidenteReaderProtocol` reply signatures changed; app and XPC service ship in the same bundle, so there is no cross-version concern.
- Verified on Apple Silicon: SMC key types match (CHTE=ui32, CHIE=hex_, ACLC=ui8); charge pause confirmed at the `pmset` level ("AC attached; not charging" at the limit).
- Builds pass both via `swift build` (Swift 6 strict) and `BuildSupport/build_app.sh` (Swift 5 mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)